### PR TITLE
Geocoding Location Marks

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -5,3 +5,4 @@ redis==2.10.3
 django-grappelli==2.7.3
 boto3==1.2.3
 Pillow==3.3.0
+googlemaps==2.4.4

--- a/src/hopespace/migrations/0011_locationmark_city_country.py
+++ b/src/hopespace/migrations/0011_locationmark_city_country.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('hopespace', '0010_auto_20160717_1632'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='locationmark',
+            name='city',
+            field=models.TextField(null=True, blank=True),
+        ),
+        migrations.AddField(
+            model_name='locationmark',
+            name='country',
+            field=models.TextField(null=True, blank=True),
+        ),
+    ]

--- a/src/hopespace/models.py
+++ b/src/hopespace/models.py
@@ -7,6 +7,8 @@ from time import time
 from PIL import Image
 from StringIO import StringIO
 
+from hopespace.utils import geocode
+
 
 def upload_image_to(instance, filename):
     return 'media/marks/%s/%s' % (instance.user.username, filename)
@@ -26,6 +28,8 @@ class LocationMark(models.Model):
     point = models.PointField()
     user = models.ForeignKey(settings.AUTH_USER_MODEL, related_name='marks')
     text = models.TextField(null=True, blank=True)
+    city = models.TextField(null=True, blank=True)
+    country = models.TextField(null=True, blank=True)
     created = models.DateTimeField(editable=False, auto_now_add=True)
     modified = models.DateTimeField(auto_now=True)
 
@@ -82,6 +86,13 @@ class LocationMark(models.Model):
             self.thumbnail_picture = InMemoryUploadedFile(output, 'ImageField',
                         image_name + '_thumbnail.png', 'image/png',
                         output.len, None)
+
+        if self.point:
+            (city, state, country) = geocode(self.point.x, self.point.y)
+            # Save the state if the city is not available
+            self.city = city if city else state
+            self.country = country
+
         super(LocationMark, self).save(*args, **kwargs)
 
     def __unicode__(self):

--- a/src/hopespace/utils.py
+++ b/src/hopespace/utils.py
@@ -1,0 +1,20 @@
+import googlemaps
+from django.conf import settings
+
+
+def geocode(lat, lng):
+    """ Transforms a coordinate into a (city,state,country) tuple using Google Geocode API. """
+    client = googlemaps.Client(key=settings.GOOGLE_MAPS_KEY)
+    city = state = country = None
+
+    results = client.reverse_geocode((lat, lng))
+    if len(results) > 0:
+        for component in results[0]['address_components']:
+            if 'country' in component['types']:
+                country = component['long_name']
+            elif 'administrative_area_level_1' in component['types']:
+                state = component['long_name']
+            elif 'administrative_area_level_2' in component['types']:
+                city = component['long_name']
+
+    return city, state, country

--- a/src/hopestarter/settings/space.py
+++ b/src/hopestarter/settings/space.py
@@ -1,3 +1,6 @@
 # Changing this requires a migration
 
 ETHNICITY_MAX_NAME = 200
+
+# override in your local settings
+# GOOGLE_MAPS_KEY = "..."

--- a/src/hopestarter/templates/feed-post.html
+++ b/src/hopestarter/templates/feed-post.html
@@ -6,7 +6,9 @@
     <a class="username" href="/profile/{{ mark.user.username }}">{{ mark.user.profile }}</a>
     <div class="meta">
       <p>
-        <span class="ethnicity">{% for m in mark.user.membership.all %}{{ m.ethnicity }}{% include "comma.html" %}{% endfor %}</span> &middot; <span class="location">Athens, Greece</span> &middot; <span class="time">{{ mark.created|naturaltime }}</span>
+        <span class="ethnicity">{% for m in mark.user.membership.all %}{{ m.ethnicity }}{% include "comma.html" %}{% endfor %}</span>
+          &middot; <span class="location">{% if mark.city %}{{ mark.city }},{% endif %}{% if mark.country %}{{ mark.country }} &middot; {% endif %}</span>
+         <span class="time">{{ mark.created|naturaltime }}</span>
       </p>
     </div>
   </header>

--- a/src/hopestarter/templates/hopebase/userprofile_detail.html
+++ b/src/hopestarter/templates/hopebase/userprofile_detail.html
@@ -76,7 +76,7 @@
 <script>
   var data = [
     {% for mark in user_marks %}
-      {'lat': {{ mark.point.x }}, 'long': {{ mark.point.y }} },
+      {'lat': {{ mark.point.x }}, 'lng': {{ mark.point.y }} },
     {% endfor %}
   ];
 </script>

--- a/src/hopestarter/templates/hopespace/locationmark_list.html
+++ b/src/hopestarter/templates/hopespace/locationmark_list.html
@@ -44,7 +44,7 @@
 <script>
   var data = [
     {% for mark in object_list %}
-      {'lat': {{ mark.point.x }}, 'long': {{ mark.point.y }} },
+      {'lat': {{ mark.point.x }}, 'lng': {{ mark.point.y }} },
     {% endfor %}
   ];
 </script>

--- a/src/hopestarter/templates/map.html
+++ b/src/hopestarter/templates/map.html
@@ -1,5 +1,5 @@
 <script src="https://cdn.rawgit.com/googlemaps/js-marker-clusterer/gh-pages/src/markerclusterer.js"></script>
-<script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyCh5N8Kx6R2CrSNUJweWIWRD9w5MXvTr_g"></script>
+<script src="https://maps.googleapis.com/maps/api/js?key={{ google_api_key }}"></script>
 <script>
     var map = null;
     var markerClusterer = null;

--- a/src/hopestarter/templates/map.html
+++ b/src/hopestarter/templates/map.html
@@ -28,12 +28,18 @@
         });
 
         {% if view_boundary %}
-        map.fitBounds({
-            north: {{ view_boundary.north }},
-            east: {{ view_boundary.east }},
-            south: {{ view_boundary.south }},
-            west: {{ view_boundary.west }}
-        });
+        if(data.length > 1) {
+            map.fitBounds({
+                north: {{ view_boundary.north }},
+                east: {{ view_boundary.east }},
+                south: {{ view_boundary.south }},
+                west: {{ view_boundary.west }}
+            });
+        } else {
+            // Set a maximum zoom in case there is only one mark
+            map.setCenter(data[0]);
+            map.setZoom(15);
+        }
         {% else %}
         map.setCenter({ lat: 37.57070524233119, lng: 22.12646484375 });
         map.setZoom(5);
@@ -49,7 +55,7 @@
 
         var markers = coordinates.map(function(coord){
           return new google.maps.Marker({
-            position: new google.maps.LatLng(coord.lat, coord.long),
+            position: new google.maps.LatLng(coord.lat, coord.lng),
             icon: {
               url: '/static/img/single_pin.svg',
               size: new google.maps.Size(32,39),

--- a/src/hopestarter/views/public.py
+++ b/src/hopestarter/views/public.py
@@ -1,12 +1,14 @@
 from django.views.generic import ListView, DetailView
 from django.contrib.auth.models import User
+from django.conf import settings
+
 from hopespace.models import LocationMark
 from hopebase.models import UserProfile
 
 BOUNDARY_OFFSET = 0.1  # Boundary offset = 10%
 
-class LocationMarkListView(ListView):
 
+class LocationMarkListView(ListView):
 
     def get_queryset(self):
         qs = LocationMark.objects.exclude(user__profile=None)
@@ -14,6 +16,12 @@ class LocationMarkListView(ListView):
         qs = qs.select_related('user')
         qs = qs.prefetch_related('user__membership')
         return qs
+
+    def get_context_data(self, **kwargs):
+        context = super(LocationMarkListView, self).get_context_data(**kwargs)
+        context['google_api_key'] = settings.GOOGLE_MAPS_KEY
+
+        return context
 
 
 class UserProfileView(DetailView):
@@ -39,5 +47,7 @@ class UserProfileView(DetailView):
             'south': max_lat + (max_lat - min_lat) * BOUNDARY_OFFSET,
             'west': min_lng - (max_lng - min_lng) * BOUNDARY_OFFSET
         }
+
+        context['google_api_key'] = settings.GOOGLE_MAPS_KEY
 
         return context


### PR DESCRIPTION
This PR adds the following behavior:
- When a mark is saved gets the city and country name from the given coordinates using Google's reverse geocoding api, and saves them into the database.
- Shows the location data in the feed posts (if available).
- (Off-topic) Fix a zoom issue that happens when there is only one location mark in the profile page.

Some considerations:
- Sometimes Google can't find a location city or even country (I had an example in the middle of the mediterranean sea). In those cases the db fields remains in  NULL and nothing is shown in the feed posts.
- If Google can't find a location city I attempt to save the state (or region) name instead.
- You may want to create your own Google Api key in the future to have full control of it (I'm using one of my own atm)
